### PR TITLE
Add csharp type for code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a library to easily visualize the progress of a TPL Dataflow in a Consol
 Usage instructions:
 To use this library you should replace all existing TPL Dataflow block names with Deve*****Block. E.g. change:
 
-```
+```csharp
 var blockOld = new TransformManyBlock<int, string>((input) =>
 {
     return Enumerable.Range(0, input).Select(t => $"Super test: {t}");
@@ -15,7 +15,7 @@ var blockOld = new TransformManyBlock<int, string>((input) =>
 ```
 To:
 
-```
+```csharp
 var blockNew = new DeveTransformManyBlock<int, string>("Video -> Frame", (input) =>
 {
     return Enumerable.Range(0, input).Select(t => $"Super test: {t}");
@@ -24,7 +24,7 @@ var blockNew = new DeveTransformManyBlock<int, string>("Video -> Frame", (input)
 
 After that you can use the following piece of code to visualize the different blocks:
 
-```
+```csharp
 _ = Task.Run(async () =>
 {
     var baume = new Tree("Root");


### PR DESCRIPTION
I think it would be a good idea to add the C# type to the code snippet, that way you can have ssyntax highlighting.

![image](https://github.com/devedse/DeveTPLDataflowVisualizer/assets/70602890/b8befa27-d572-4bb9-b0f5-c467bb23e32f)
